### PR TITLE
Add GoReleaser workflow

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,7 +1,9 @@
 name: tagpr
+
 on:
   push:
     branches: ["main"]
+
 jobs:
   tagpr:
     runs-on: ubuntu-latest
@@ -14,3 +16,26 @@ jobs:
     - uses: Songmu/tagpr@35daec35e8e3172806c763d8f196e6434fd44fbd # v1.5.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    needs: tagpr
+    if: needs.tagpr.outputs.tagpr-tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        with:
+          version: "latest"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ go.work.sum
 .env
 
 .idea
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,55 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/switch-bot-mcp-server/
+
+archives:
+  - formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+      - goos: darwin
+        formats: [zip]
+    files:
+      - CREDITS
+      - LICENSE*
+      - README*
+
+changelog:
+  use: github-native
+
+release:
+  draft: true
+  replace_existing_draft: true
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/.tagpr
+++ b/.tagpr
@@ -45,5 +45,5 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	release = draft
+	release = false
 	versionFile = version/version.go


### PR DESCRIPTION
This pull request introduces a workflow for automating releases using GoReleaser and updates related configuration files to support this process. The changes include adding a new release job to the GitHub Actions workflow, creating a `.goreleaser.yaml` configuration file, and modifying the `.tagpr` configuration to enable non-draft releases.

### GitHub Actions Workflow Updates:
* [`.github/workflows/tagpr.yml`](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR2-R6): Added a new `release` job that depends on the `tagpr` job. It uses GoReleaser to handle the release process, including setting up Go and running the release commands. [[1]](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR2-R6) [[2]](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR19-R41)

### GoReleaser Configuration:
* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R1-R55): Introduced a new configuration file for GoReleaser. It includes sensible defaults for building, archiving, and releasing the project, such as specifying supported platforms (`linux`, `windows`, `darwin`), architectures (`amd64`, `arm64`), and file formats (`tar.gz`, `zip`).

### TagPR Configuration Update:
* [`.tagpr`](diffhunk://#diff-9cdd8f7c83987d956c63941ff0054acf6b5e96247c546f746bb87e07efb72550L48-R48): Updated the configuration to disable draft releases by setting `release = false`. This ensures that releases are published immediately instead of being saved as drafts.