### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -11,9 +11,12 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+    outputs:
+      tagpr-tag: ${{ steps.run-tagpr.outputs.tag }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: Songmu/tagpr@35daec35e8e3172806c763d8f196e6434fd44fbd # v1.5.2
+    - id: run-tagpr
+      uses: Songmu/tagpr@35daec35e8e3172806c763d8f196e6434fd44fbd # v1.5.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/tagpr.yml` file to enhance the workflow by adding an output for the `tagpr` action and assigning an ID to its step for better reference.

Enhancements to the GitHub Actions workflow:

* Added an `outputs` section to expose the `tagpr-tag` output from the `tagpr` action, enabling downstream steps to access the generated tag.
* Assigned an ID (`run-tagpr`) to the `tagpr` step, allowing other steps in the workflow to reference its outputs.