### PR TITLE
update README to include new command execution tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Follow the [Getting Started guide of SwitchBotAPI](https://github.com/OpenWonder
 
 ## Available Tools
 
-Currently, only a few tools are available, such as retrieving devices, retrieving statuses, and executing ON/OFF commands.
+Retrieving devices, retrieving statuses, and executing commands on devices are available.
 
-| Tool Name                      | Description                 |
-|--------------------------------|-----------------------------|
-| `get_switch_bot_devices`       | Get SwitchBot devices       |
-| `get_switch_bot_device_status` | Get SwitchBot device status |
-| `turn_on_off_device`           | Turn on/off device          |
+| Tool Name                      | Description                   |
+|--------------------------------|-------------------------------|
+| `get_switch_bot_devices`       | Get SwitchBot devices         |
+| `get_switch_bot_device_status` | Get SwitchBot device status   |
+| `execute_command`              | Execute a command on a device |

--- a/README_ja.md
+++ b/README_ja.md
@@ -43,10 +43,10 @@ SwitchBot MCP Serverは[SwitchBotAPI](https://github.com/OpenWonderLabs/SwitchBo
 
 ## 利用可能なツール
 
-現在はデバイスの取得とステータスの取得、ON/OFFコマンドの実行の一部ツールのみが利用可能です。
+デバイスの取得とステータスの取得、デバイスのコマンドの実行が利用可能です。
 
-| Tool Name                      | Description                 |
-|--------------------------------|-----------------------------|
-| `get_switch_bot_devices`       | Get SwitchBot devices       |
-| `get_switch_bot_device_status` | Get SwitchBot device status |
-| `turn_on_off_device`           | Turn on/off device          |
+| Tool Name                      | Description                   |
+|--------------------------------|-------------------------------|
+| `get_switch_bot_devices`       | Get SwitchBot devices         |
+| `get_switch_bot_device_status` | Get SwitchBot device status   |
+| `execute_command`              | Execute a command on a device |


### PR DESCRIPTION
This pull request updates the documentation in both `README.md` and `README_ja.md` to reflect changes in the available tools for interacting with SwitchBot devices. The updates clarify the functionality and improve consistency in the descriptions.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R52): Updated the description of available tools to clarify that commands can now be executed on devices, and replaced `turn_on_off_device` with `execute_command` in the tools list.
* [`README_ja.md`](diffhunk://#diff-f352f176b719ca7e5c1025e2c75daa964dc961db4de4768a58a4b84fbee095b0L46-R52): Made similar updates in the Japanese documentation, reflecting the ability to execute commands on devices and replacing `turn_on_off_device` with `execute_command`.