### PR TITLE
Support Docker Image

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -42,3 +42,40 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-release:
+    needs: tagpr
+    if: needs.tagpr.outputs.tagpr-tag != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up tag without 'v' prefix
+        id: set_tag
+        run: |
+          TAG="${{ needs.tagpr.outputs.tagpr-tag }}"
+          echo "TAG_WITHOUT_V=${TAG#v}" >> $GITHUB_OUTPUT
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            yasu89/switch-bot-mcp-server:latest
+            yasu89/switch-bot-mcp-server:${{ steps.set_tag.outputs.TAG_WITHOUT_V }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-name: index.docker.io/yasu89/switch-bot-mcp-server
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.24.4-alpine3.22 AS builder
+WORKDIR /workspace
+COPY . /workspace/
+RUN go mod download
+RUN go build -o switch-bot-mcp-server cmd/switch-bot-mcp-server/main.go
+
+FROM alpine:3.22 AS runtime
+COPY --from=builder /workspace/switch-bot-mcp-server /usr/bin/switch-bot-mcp-server
+
+CMD ["switch-bot-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -17,15 +17,47 @@ The SwitchBot MCP Server is a [Model Context Protocol (MCP)](https://modelcontex
 
 ## Installation
 
-### Prepare binary
-
-Download binary from [release page](https://github.com/yasu89/switch-bot-mcp-server/releases).
-
 ### Prepare secret and token
 
 Follow the [Getting Started guide of SwitchBotAPI](https://github.com/OpenWonderLabs/SwitchBotAPI?tab=readme-ov-file#getting-started) to obtain the token and secret for SwitchBotAPI.
 
 ### Setting for Claude Desktop
+
+#### Using Docker (recommended)
+
+```json
+{
+  "mcpServers": {
+    "switchbot": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "--name",
+        "switch-bot-mcp-server",
+        "-e",
+        "SWITCH_BOT_TOKEN",
+        "-e",
+        "SWITCH_BOT_SECRET",
+        "yasu89/switch-bot-mcp-server:alpha"
+      ],
+      "env": {
+        "SWITCH_BOT_TOKEN": "YOUR_SWITCH_BOT_TOKEN",
+        "SWITCH_BOT_SECRET": "YOUR_SWITCH_BOT_SECRET"
+      }
+    }
+  }
+}
+```
+
+#### Using binary
+
+<details>
+
+<summary>Details</summary>
+
+Download binary from [release page](https://github.com/yasu89/switch-bot-mcp-server/releases).
 
 ```json
 {
@@ -40,6 +72,8 @@ Follow the [Getting Started guide of SwitchBotAPI](https://github.com/OpenWonder
   }
 }
 ```
+
+</details>
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Follow the [Getting Started guide of SwitchBotAPI](https://github.com/OpenWonder
         "SWITCH_BOT_TOKEN",
         "-e",
         "SWITCH_BOT_SECRET",
-        "yasu89/switch-bot-mcp-server:alpha"
+        "yasu89/switch-bot-mcp-server:latest"
       ],
       "env": {
         "SWITCH_BOT_TOKEN": "YOUR_SWITCH_BOT_TOKEN",

--- a/README_ja.md
+++ b/README_ja.md
@@ -40,7 +40,7 @@ SwitchBot MCP Serverは[SwitchBotAPI](https://github.com/OpenWonderLabs/SwitchBo
         "SWITCH_BOT_TOKEN",
         "-e",
         "SWITCH_BOT_SECRET",
-        "yasu89/switch-bot-mcp-server:alpha"
+        "yasu89/switch-bot-mcp-server:latest"
       ],
       "env": {
         "SWITCH_BOT_TOKEN": "YOUR_SWITCH_BOT_TOKEN",

--- a/README_ja.md
+++ b/README_ja.md
@@ -17,15 +17,47 @@ SwitchBot MCP Serverは[SwitchBotAPI](https://github.com/OpenWonderLabs/SwitchBo
 
 ## インストール方法
 
-### バイナリ準備
-
-[リリースページ](https://github.com/yasu89/switch-bot-mcp-server/releases)からダウンロードしてください。
-
 ### シークレットとトークンの準備
 
 [SwitchBotAPIのGetting Started](https://github.com/OpenWonderLabs/SwitchBotAPI?tab=readme-ov-file#getting-started)に従って、SwitchBotAPIのトークンとシークレットを取得してください。
 
 ### Claude Desktopで使用する場合の設定
+
+#### Dockerを使用する(推奨)
+
+```json
+{
+  "mcpServers": {
+    "switchbot": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "--name",
+        "switch-bot-mcp-server",
+        "-e",
+        "SWITCH_BOT_TOKEN",
+        "-e",
+        "SWITCH_BOT_SECRET",
+        "yasu89/switch-bot-mcp-server:alpha"
+      ],
+      "env": {
+        "SWITCH_BOT_TOKEN": "YOUR_SWITCH_BOT_TOKEN",
+        "SWITCH_BOT_SECRET": "YOUR_SWITCH_BOT_SECRET"
+      }
+    }
+  }
+}
+```
+
+#### バイナリを使用する
+
+<details>
+
+<summary>詳細</summary>
+
+[リリースページ](https://github.com/yasu89/switch-bot-mcp-server/releases)からダウンロードしてください。
 
 ```json
 {
@@ -40,6 +72,8 @@ SwitchBot MCP Serverは[SwitchBotAPI](https://github.com/OpenWonderLabs/SwitchBo
   }
 }
 ```
+
+</details>
 
 ## 利用可能なツール
 


### PR DESCRIPTION
This pull request introduces Docker support for the SwitchBot MCP Server, updates the workflow to include Docker image creation and publication, and revises the documentation to reflect these changes. The most significant updates include adding a Dockerfile, modifying the GitHub Actions workflow to build and push Docker images, and enhancing the README files with instructions for using Docker.

### Docker support:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R10): Added a multi-stage Dockerfile to build and package the SwitchBot MCP Server application. The first stage compiles the Go binary, and the second stage creates a lightweight runtime image.

### GitHub Actions workflow updates:

* [`.github/workflows/tagpr.yml`](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR45-R81): Added a new `docker-release` job to build and push Docker images to Docker Hub. This includes setting up QEMU and Buildx for multi-platform builds, logging into Docker Hub, and generating an artifact attestation.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R61): Updated installation instructions to recommend using Docker for running the server, including a sample configuration for Claude Desktop. Binary usage instructions were moved into a collapsible section for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R61) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76-R77)
* [`README_ja.md`](diffhunk://#diff-f352f176b719ca7e5c1025e2c75daa964dc961db4de4768a58a4b84fbee095b0L20-R61): Updated Japanese documentation to mirror the changes in the English README, recommending Docker usage and reorganizing binary instructions into a collapsible section. [[1]](diffhunk://#diff-f352f176b719ca7e5c1025e2c75daa964dc961db4de4768a58a4b84fbee095b0L20-R61) [[2]](diffhunk://#diff-f352f176b719ca7e5c1025e2c75daa964dc961db4de4768a58a4b84fbee095b0R76-R77)