### PR TITLE
Fix Docker Image Build Action

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -48,6 +48,10 @@ jobs:
     if: needs.tagpr.outputs.tagpr-tag != ''
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
       - name: Set up tag without 'v' prefix
         id: set_tag
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/tagpr.yml` to include a new step for checking out the repository.

Workflow configuration changes:

* [`.github/workflows/tagpr.yml`](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR51-R54): Added a `Checkout` step using the `actions/checkout` action (version `v4.2.2`) with `fetch-depth: 0` to ensure a full repository history is fetched.